### PR TITLE
Feature/refactor

### DIFF
--- a/filestore.go
+++ b/filestore.go
@@ -24,11 +24,6 @@ const (
 
 var chunkSize int64 = 10 * 1024 * 1024
 
-type PathConfig struct {
-	Path  string
-	Paths []string
-}
-
 type FileOperationOutput struct {
 	Md5 string
 }
@@ -74,13 +69,12 @@ type UploadResult struct {
 
 type FileVisitFunction func(path string, file os.FileInfo) error
 
-//@TODO evaluate PathConfig as an input.  should this just be a string path.....
 type FileStore interface {
-	GetDir(path PathConfig) (*[]FileStoreResultObject, error)
-	GetObject(PathConfig) (io.ReadCloser, error)
-	PutObject(PathConfig, []byte) (*FileOperationOutput, error)
+	GetDir(string) (*[]FileStoreResultObject, error)
+	GetObject(string) (io.ReadCloser, error)
+	PutObject(string, []byte) (*FileOperationOutput, error)
 	DeleteObject(path string) error //depricate eventually?
-	DeleteObjects(path PathConfig) error
+	DeleteObjects(path ...string) error
 	//PutMultipartObject(u UploadConfig) (UploadResult, error)
 	//InitializeMultipartWrite
 	//PutPart(u UploadConfig) (UploadResult, error)

--- a/filestore.go
+++ b/filestore.go
@@ -73,7 +73,6 @@ type FileStore interface {
 	GetDir(string) (*[]FileStoreResultObject, error)
 	GetObject(string) (io.ReadCloser, error)
 	PutObject(string, []byte) (*FileOperationOutput, error)
-	DeleteObject(path string) error //depricate eventually?
 	DeleteObjects(path ...string) error
 	//PutMultipartObject(u UploadConfig) (UploadResult, error)
 	//InitializeMultipartWrite

--- a/filestore.go
+++ b/filestore.go
@@ -70,7 +70,7 @@ type UploadResult struct {
 type FileVisitFunction func(path string, file os.FileInfo) error
 
 type FileStore interface {
-	GetDir(string) (*[]FileStoreResultObject, error)
+	GetDir(string, bool) (*[]FileStoreResultObject, error)
 	GetObject(string) (io.ReadCloser, error)
 	PutObject(string, []byte) (*FileOperationOutput, error)
 	DeleteObjects(path ...string) error
@@ -101,10 +101,9 @@ func NewFileStore(config interface{}) (FileStore, error) {
 		}
 
 		fs := S3FS{
-			session:   sess,
-			config:    &s3config,
-			delimiter: "/",
-			maxKeys:   1000,
+			session: sess,
+			config:  &s3config,
+			maxKeys: 1000,
 		}
 		return &fs, nil
 

--- a/filestore.go
+++ b/filestore.go
@@ -2,7 +2,6 @@ package filestore
 
 import (
 	"crypto/md5"
-	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -108,7 +107,7 @@ func NewFileStore(config interface{}) (FileStore, error) {
 		return &fs, nil
 
 	default:
-		return nil, errors.New(fmt.Sprintf("Invalid File System System Type Configuration: %v", scType))
+		return nil, fmt.Errorf("Invalid File System System Type Configuration: %v", scType)
 	}
 }
 

--- a/filesystemstore.go
+++ b/filesystemstore.go
@@ -45,16 +45,6 @@ func (b *BlockFS) GetObject(path string) (io.ReadCloser, error) {
 	return os.Open(path)
 }
 
-func (b *BlockFS) DeleteObject(path string) error {
-	var err error
-	if isDir(path) {
-		err = os.RemoveAll(path)
-	} else {
-		err = os.Remove(path)
-	}
-	return err
-}
-
 func (b *BlockFS) DeleteObjects(path ...string) error {
 	var err error
 	for _, p := range path {

--- a/filesystemstore.go
+++ b/filesystemstore.go
@@ -18,9 +18,9 @@ type BlockFSConfig struct{}
 
 type BlockFS struct{}
 
-func (b *BlockFS) GetDir(path PathConfig) (*[]FileStoreResultObject, error) {
-	fmt.Println(path.Path)
-	dirContents, err := ioutil.ReadDir(path.Path)
+func (b *BlockFS) GetDir(path string) (*[]FileStoreResultObject, error) {
+	fmt.Println(path)
+	dirContents, err := ioutil.ReadDir(path)
 	if err != nil {
 		return nil, err
 	}
@@ -31,7 +31,7 @@ func (b *BlockFS) GetDir(path PathConfig) (*[]FileStoreResultObject, error) {
 			ID:         i,
 			Name:       f.Name(),
 			Size:       size,
-			Path:       path.Path,
+			Path:       path,
 			Type:       filepath.Ext(f.Name()),
 			IsDir:      f.IsDir(),
 			Modified:   f.ModTime(),
@@ -41,8 +41,8 @@ func (b *BlockFS) GetDir(path PathConfig) (*[]FileStoreResultObject, error) {
 	return &objects, nil
 }
 
-func (b *BlockFS) GetObject(path PathConfig) (io.ReadCloser, error) {
-	return os.Open(path.Path)
+func (b *BlockFS) GetObject(path string) (io.ReadCloser, error) {
+	return os.Open(path)
 }
 
 func (b *BlockFS) DeleteObject(path string) error {
@@ -55,9 +55,9 @@ func (b *BlockFS) DeleteObject(path string) error {
 	return err
 }
 
-func (b *BlockFS) DeleteObjects(path PathConfig) error {
+func (b *BlockFS) DeleteObjects(path ...string) error {
 	var err error
-	for _, p := range path.Paths {
+	for _, p := range path {
 		if isDir(p) {
 			err = os.RemoveAll(p)
 		} else {
@@ -67,13 +67,13 @@ func (b *BlockFS) DeleteObjects(path PathConfig) error {
 	return err
 }
 
-func (b *BlockFS) PutObject(path PathConfig, data []byte) (*FileOperationOutput, error) {
+func (b *BlockFS) PutObject(path string, data []byte) (*FileOperationOutput, error) {
 	if len(data) == 0 {
 		f := FileOperationOutput{}
-		err := os.MkdirAll(filepath.Dir(path.Path), os.ModePerm)
+		err := os.MkdirAll(filepath.Dir(path), os.ModePerm)
 		return &f, err
 	} else {
-		f, err := os.OpenFile(path.Path, os.O_WRONLY|os.O_CREATE, 0644)
+		f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE, 0644)
 		if err != nil {
 			return nil, err
 		}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
-module di2e.net/cwbi/filestore
+module github.com/USACE/filestore
 
-go 1.13
+go 1.15
 
 require (
 	github.com/aws/aws-sdk-go v1.31.0

--- a/s3store.go
+++ b/s3store.go
@@ -123,27 +123,6 @@ func (s3fs *S3FS) GetObject(path string) (io.ReadCloser, error) {
 	return output.Body, err
 }
 
-func (s3fs *S3FS) DeleteObject(path string) error {
-	s3Path := strings.TrimPrefix(path, "/")
-	svc := s3.New(s3fs.session)
-	input := &s3.DeleteObjectsInput{
-		Bucket: aws.String(s3fs.config.S3Bucket),
-		Delete: &s3.Delete{
-			Objects: []*s3.ObjectIdentifier{
-				{
-					Key: aws.String(s3Path),
-				},
-			},
-			Quiet: aws.Bool(false),
-		},
-	}
-	output, err := s3fs.deleteObjectsImpl(svc, input)
-	log.Println("--------DELETE OPERATION OUTPUT------------")
-	log.Print(output)
-	log.Println("--------DELETE OPERATION OUTPUT------------")
-	return err
-}
-
 func (s3fs *S3FS) PutObject(path string, data []byte) (*FileOperationOutput, error) {
 	s3Path := strings.TrimPrefix(path, "/")
 	svc := s3.New(s3fs.session)

--- a/s3store.go
+++ b/s3store.go
@@ -306,3 +306,10 @@ func (s3fs *S3FS) SetObjectPublic(path string) (string, error) {
 	_, err := svc.PutObjectAcl(input)
 	return url, err
 }
+
+// Ping makes a cheap call to the s3 bucket to ensure connection
+func (s3fs *S3FS) Ping() error {
+	svc := s3.New(s3fs.session)
+	_, err := svc.GetBucketAcl(&s3.GetBucketAclInput{Bucket: aws.String(s3fs.config.S3Bucket)})
+	return err
+}

--- a/s3store.go
+++ b/s3store.go
@@ -143,11 +143,6 @@ func (s3fs *S3FS) PutObject(path string, data []byte) (*FileOperationOutput, err
 	return output, err
 }
 
-func (s3fs *S3FS) deleteObjectsImpl(svc *s3.S3, input *s3.DeleteObjectsInput) (*s3.DeleteObjectsOutput, error) {
-	result, err := svc.DeleteObjects(input)
-	return result, err
-}
-
 func (s3fs *S3FS) DeleteObjects(path ...string) error {
 	svc := s3.New(s3fs.session)
 	objects := make([]*s3.ObjectIdentifier, 0, len(path))
@@ -168,7 +163,7 @@ func (s3fs *S3FS) DeleteObjects(path ...string) error {
 		},
 	}
 
-	output, err := s3fs.deleteObjectsImpl(svc, input)
+	output, err := svc.DeleteObjects(input)
 	log.Println("--------DELETE OPERATION OUTPUT------------")
 	log.Print(output)
 	log.Println("--------DELETE OPERATION OUTPUT------------")

--- a/s3store.go
+++ b/s3store.go
@@ -15,34 +15,42 @@ import (
 	"github.com/aws/aws-sdk-go/service/s3"
 )
 
+// S3FileInfo is a wrapper around the s3.Object struct that implements the os.FileInfo interface
 type S3FileInfo struct {
 	s3 *s3.Object
 }
 
+// Name returns the file name of the s3 object
 func (obj *S3FileInfo) Name() string {
 	return *obj.s3.Key
 }
 
+// Size returns the file size in bytes
 func (obj *S3FileInfo) Size() int64 {
 	return *obj.s3.Size
 }
 
+// Mode defaults to Irregular
 func (obj *S3FileInfo) Mode() os.FileMode {
 	return os.ModeIrregular
 }
 
+// ModTime returns the time the s3 object was last modified
 func (obj *S3FileInfo) ModTime() time.Time {
 	return *obj.s3.LastModified
 }
 
+// IsDir returns a boolean determining whether an object is a directory or not
 func (obj *S3FileInfo) IsDir() bool {
 	return false
 }
 
+// Sys defaults to nil for objects of s3
 func (obj *S3FileInfo) Sys() interface{} {
 	return nil
 }
 
+// S3FSConfig stores the configuration and credentials necessary to create an s3 instance of the filestore
 type S3FSConfig struct {
 	S3Id     string
 	S3Key    string
@@ -50,12 +58,14 @@ type S3FSConfig struct {
 	S3Bucket string
 }
 
+// S3FS satisfies the FileStore interface, allowing for generic file operations to be done on s3 blobs
 type S3FS struct {
 	session *session.Session
 	config  *S3FSConfig
 	maxKeys int64
 }
 
+// GetDir is similar to an ls unix call. It lists the objects at an s3 prefix, with the option of being recursive
 func (s3fs *S3FS) GetDir(path string, recursive bool) (*[]FileStoreResultObject, error) {
 	s3Path := strings.Trim(path, "/") + "/"
 	var delim string
@@ -116,6 +126,7 @@ func (s3fs *S3FS) GetDir(path string, recursive bool) (*[]FileStoreResultObject,
 	return &result, nil
 }
 
+// GetObject will return the body of an s3 object as a ReadCloser, meaning it has the basic Read and Close methods
 func (s3fs *S3FS) GetObject(path string) (io.ReadCloser, error) {
 	s3Path := strings.TrimPrefix(path, "/")
 	svc := s3.New(s3fs.session)
@@ -127,6 +138,7 @@ func (s3fs *S3FS) GetObject(path string) (io.ReadCloser, error) {
 	return output.Body, err
 }
 
+// PutObject will take the data provided and put it on s3 at the path provided
 func (s3fs *S3FS) PutObject(path string, data []byte) (*FileOperationOutput, error) {
 	s3Path := strings.TrimPrefix(path, "/")
 	svc := s3.New(s3fs.session)
@@ -143,6 +155,7 @@ func (s3fs *S3FS) PutObject(path string, data []byte) (*FileOperationOutput, err
 	return &FileOperationOutput{Md5: *s3output.ETag}, nil
 }
 
+// DeleteObjects will take one or more paths, and delete them from the s3 file system
 func (s3fs *S3FS) DeleteObjects(path ...string) error {
 	svc := s3.New(s3fs.session)
 	objects := make([]*s3.ObjectIdentifier, 0, len(path))
@@ -232,6 +245,7 @@ func (s3fs *S3FS) CompleteObjectUpload(u CompletedObjectUploadConfig) error {
 	return err
 }
 
+// Walk will traverse an s3 file system recursively, starting at the provided prefix, and apply the visitorFunction to each s3 object
 func (s3fs *S3FS) Walk(path string, vistorFunction FileVisitFunction) error {
 	s3Path := strings.TrimPrefix(path, "/")
 	s3delim := ""
@@ -265,6 +279,8 @@ func (s3fs *S3FS) Walk(path string, vistorFunction FileVisitFunction) error {
 /*
   these functions are not part of the filestore interface and are unique to the S3FS
 */
+
+// SharedAccessURL will create a presigned url that can be used to access/download an object from an s3 bucket. It will only be valid for the duration specified
 func (s3fs *S3FS) SharedAccessURL(path string, expiration time.Duration) (string, error) {
 	s3Path := strings.TrimPrefix(path, "/")
 	svc := s3.New(s3fs.session)
@@ -276,6 +292,7 @@ func (s3fs *S3FS) SharedAccessURL(path string, expiration time.Duration) (string
 	return req.Presign(expiration)
 }
 
+// SetObjectPublic will change the acl permissions on an s3 object and make it publically readable
 func (s3fs *S3FS) SetObjectPublic(path string) (string, error) {
 	s3Path := strings.TrimPrefix(path, "/")
 	svc := s3.New(s3fs.session)

--- a/s3store.go
+++ b/s3store.go
@@ -52,14 +52,17 @@ type S3FSConfig struct {
 }
 
 type S3FS struct {
-	session   *session.Session
-	config    *S3FSConfig
-	delimiter string
-	maxKeys   int64
+	session *session.Session
+	config  *S3FSConfig
+	maxKeys int64
 }
 
-func (s3fs *S3FS) GetDir(path string) (*[]FileStoreResultObject, error) {
-	s3Path := strings.TrimPrefix(path, "/")
+func (s3fs *S3FS) GetDir(path string, recursive bool) (*[]FileStoreResultObject, error) {
+	s3Path := strings.Trim(path, "/") + "/"
+	var delim string
+	if !recursive {
+		delim = "/"
+	}
 	fmt.Println("<<<<<<<>>>>>>>>>")
 	fmt.Println("S3 DIR Request")
 	fmt.Println(s3Path)
@@ -68,7 +71,7 @@ func (s3fs *S3FS) GetDir(path string) (*[]FileStoreResultObject, error) {
 	params := &s3.ListObjectsV2Input{
 		Bucket:            aws.String(s3fs.config.S3Bucket),
 		Prefix:            &s3Path,
-		Delimiter:         &s3fs.delimiter,
+		Delimiter:         aws.String(delim),
 		MaxKeys:           &s3fs.maxKeys,
 		ContinuationToken: nil,
 	}


### PR DESCRIPTION
## Updates
 - Go version to 1.15
 - go.mod module name to `github.com/USACE/filestore`
 - Removes the `PathConfig` struct and `DeleteObject` method, instead allowing one or more paths to be passed to `DeleteObjects`
 - Change the name of `GetPresignedUrl` to `SharedAccessURL`
## Adds
 - A recursive option to `GetDir`
 - A continuation token to the s3 `GetDir`
 - Add doc comments to `s3store.go`
 - allow for any `time.Duration` to be passed to `SharedAccessURL`