### PR TITLE
add bucket to s3fs PutObject

### DIFF
--- a/s3store.go
+++ b/s3store.go
@@ -144,6 +144,7 @@ func (s3fs *S3FS) PutObject(path string, data []byte) (*FileOperationOutput, err
 	svc := s3.New(s3fs.session)
 	reader := bytes.NewReader(data)
 	input := &s3.PutObjectInput{
+		Bucket:        aws.String(s3fs.config.S3Bucket),
 		Body:          reader,
 		ContentLength: aws.Int64(int64(len(data))),
 		Key:           aws.String(s3Path),


### PR DESCRIPTION
Add the bucket to the s3fs.PutObject method. It was missing, which led to the following error:

```InvalidParameter: 1 validation error(s) found.\n- missing required field, PutObjectInput.Bucket.```