### PR TITLE
Update the s3fs ping method to use ListObjectsV2

### DIFF
--- a/s3store.go
+++ b/s3store.go
@@ -317,6 +317,10 @@ func (s3fs *S3FS) SetObjectPublic(path string) (string, error) {
 // Ping makes a cheap call to the s3 bucket to ensure connection
 func (s3fs *S3FS) Ping() error {
 	svc := s3.New(s3fs.session)
-	_, err := svc.GetBucketAcl(&s3.GetBucketAclInput{Bucket: aws.String(s3fs.config.S3Bucket)})
+	listInput := &s3.ListObjectsV2Input{
+		Bucket:  aws.String(s3fs.config.S3Bucket),
+		MaxKeys: aws.Int64(1),
+	}
+	_, err := svc.ListObjectsV2(listInput)
 	return err
 }


### PR DESCRIPTION
This PR updates the S3FS ping method to use ListObjectsV2 instead of GetObjectAcl. A user with restricted permissions is able to list objects within a bucket but not get the access control list. If a user enters the incorrect credentials or the name of a bucket that does not exist, the ping will return an error, otherwise the error will be nil.